### PR TITLE
Change License to EPLv2 (fixup)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -51,7 +51,7 @@
        This program and the accompanying materials are made
        available under the terms of the Eclipse Public License 2.0
        which accompanies this distribution, and is available at
-       http://www.eclipse.org/legal/epl-v10.htm
+       https://www.eclipse.org/legal/epl-2.0/
       		</comments>
 		</license>
 	</licenses>


### PR DESCRIPTION
A case the script missed because the original URL to v1 had a typo